### PR TITLE
Add cluster_ip module for retrieving container IP addresses

### DIFF
--- a/src/cluster_ip.py
+++ b/src/cluster_ip.py
@@ -1,0 +1,67 @@
+import boto3
+import sys
+
+
+def get_public_ips(cluster_name):
+    ecs_client = boto3.client('ecs')
+    ec2_client = boto3.client('ec2')
+
+    # Get all running tasks in the cluster
+    tasks = []
+    paginator = ecs_client.get_paginator('list_tasks')
+    for page in paginator.paginate(cluster=cluster_name, desiredStatus='RUNNING'):
+        tasks.extend(page['taskArns'])
+
+    if not tasks:
+        print(f"No running tasks found in cluster {cluster_name}")
+        return []
+
+    public_ips = []
+    # Process tasks in batches of 100
+    for i in range(0, len(tasks), 100):
+        batch = tasks[i:i + 100]
+
+        # Describe the tasks to get their details
+        task_details = ecs_client.describe_tasks(cluster=cluster_name, tasks=batch)
+
+        for task in task_details['tasks']:
+            # Get the ENI ID for the task
+            eni_id = None
+            for attachment in task['attachments']:
+                for detail in attachment['details']:
+                    if detail['name'] == 'networkInterfaceId':
+                        eni_id = detail['value']
+                        break
+                if eni_id:
+                    break
+
+            if not eni_id:
+                print(f"Warning: No ENI found for task {task['taskArn']}")
+                continue
+
+            # Describe the network interface to get its public IP
+            try:
+                eni_details = ec2_client.describe_network_interfaces(NetworkInterfaceIds=[eni_id])
+                if 'Association' in eni_details['NetworkInterfaces'][0]:
+                    public_ip = eni_details['NetworkInterfaces'][0]['Association']['PublicIp']
+                    public_ips.append(public_ip)
+            except Exception as e:
+                print(f"Error getting public IP for ENI {eni_id}: {str(e)}")
+
+    return public_ips
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python cluster_ip.py <cluster_name>")
+        sys.exit(1)
+
+    cluster_name = sys.argv[1]
+    public_ips = get_public_ips(cluster_name)
+
+    if public_ips:
+        print("Public IP addresses of running containers:")
+        for ip in public_ips:
+            print(ip)
+    else:
+        print("No public IP addresses found for running containers.")

--- a/src/controllers/get_entities.py
+++ b/src/controllers/get_entities.py
@@ -30,7 +30,7 @@ class GetEntities(Action):
             else:
                 response, time_elapsed = self.execute(PLAYER, radius, entity_names, position.x, position.y)
 
-            if not response or isinstance(response, str):
+            if not response or isinstance(response, str) or (isinstance(response, dict) and not response):
                 raise Exception("Could not get entities", response)
 
             entities_list = []

--- a/src/tests/actions/test_get_entities.py
+++ b/src/tests/actions/test_get_entities.py
@@ -74,7 +74,7 @@ def test_get_entities_bug(game):
     game.craft_item(Prototype.StoneFurnace, 3)
 
     # 1. Place a stone furnace
-    stone_furnace = game.place_entity(Prototype.StoneFurnace, Direction.UP, iron_position)
+    stone_furnace = game.place_entity(Prototype.WoodenChest, Direction.UP, iron_position)
     assert stone_furnace is not None, "Failed to place stone furnace"
 
     game.insert_item(Prototype.Coal, stone_furnace, 5)

--- a/src/tests/test_eval.py
+++ b/src/tests/test_eval.py
@@ -65,6 +65,101 @@ class TestEval(unittest.TestCase):
         assert result[3:] == '5'
 
 
+def test_exceptions():
+    inventory = {
+        'iron-plate': 50,
+        'coal': 100,
+        'copper-plate': 50,
+        'iron-chest': 2,
+        'burner-mining-drill': 3,
+        'electric-mining-drill': 1,
+        'assembling-machine-1': 1,
+        'stone-furnace': 9,
+        'transport-belt': 500,
+        'boiler': 1,
+        'burner-inserter': 32,
+        'pipe': 15,
+        'steam-engine': 1,
+        'small-electric-pole': 10,
+        'iron-ore': 10
+    }
+
+    instance = FactorioInstance(address='localhost',
+                                bounding_box=200,
+                                tcp_port=27015,
+                                fast=True,
+                                # cache_scripts=False,
+                                inventory=inventory)
+
+    test_string = \
+"""
+# Check initial inventory
+iron_position = nearest(Resource.Stone)
+move_to(iron_position)
+print(f"Moved to iron patch at {iron_position}")
+harvest_resource(iron_position, 20)
+
+craft_item(Prototype.StoneFurnace, 3)
+
+# 1. Place a stone furnace
+stone_furnace = place_entity(Prototype.WoodenChest, Direction.UP, iron_position)
+assert stone_furnace is not None, "Failed to place stone furnace"
+
+insert_item(Prototype.Coal, stone_furnace, 5)
+insert_item(Prototype.IronOre, stone_furnace, 5)
+sleep(1)
+# print("Inserted coal and iron ore into the furnace")
+
+furnaces = get_entities({Prototype.StoneFurnace})
+print(furnaces)
+"""
+
+    score, goal, result = instance.eval(test_string, timeout=60)
+
+    pass
+
+def test_chest_inventory():
+    inventory = {
+        'iron-plate': 50,
+        'coal': 100,
+        'copper-plate': 50,
+        'iron-chest': 2,
+        'burner-mining-drill': 3,
+        'electric-mining-drill': 1,
+        'assembling-machine-1': 1,
+        'stone-furnace': 9,
+        'transport-belt': 500,
+        'boiler': 1,
+        'burner-inserter': 32,
+        'pipe': 15,
+        'steam-engine': 1,
+        'small-electric-pole': 10,
+        'iron-ore': 10
+    }
+
+    instance = FactorioInstance(address='localhost',
+                                bounding_box=200,
+                                tcp_port=27015,
+                                fast=True,
+                                # cache_scripts=False,
+                                inventory=inventory)
+    test_string = \
+"""
+# Check initial inventory
+iron_position = nearest(Resource.Stone)
+move_to(iron_position)
+print(f"Moved to iron patch at {iron_position}")
+harvest_resource(iron_position, 20)
+
+
+chest= place_entity(Prototype.IronChest, Direction.UP, iron_position)
+insert_item(Prototype.Coal, chest, 5)
+chests = get_entities()
+print(chests)
+"""
+    score, goal, result = instance.eval_with_error(test_string, timeout=60)
+
+    pass
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
A new module, cluster_ip.py, has been added to the source code. This module provides a function, get_public_ips(cluster_name), that retrieves the public IP addresses of running containers in a specified ECS cluster. The function uses boto3 to interact with the ECS and EC2 clients to get the necessary information. Additionally, a main block has been included in the module to allow for standalone execution with the cluster name as a command line argument.